### PR TITLE
Fix for libdnet symlink

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,7 +164,7 @@ snort_dynamic_library_rules: []
   #- web-iis.rules
   #- web-misc.rules
 snort_external_net: '!$HOME_NET'  #define external networks..if snort_home_net is any then set this to any
-snort_fedora_package: 'https://www.snort.org/downloads/snort/snort-{{ snort_version }}-1.f21.x86_64.rpm'
+snort_fedora_package: 'https://www.snort.org/downloads/snort/snort-{{ snort_version }}-1.f25.x86_64.rpm'
 snort_fedora_daq_package: 'https://www.snort.org/downloads/snort/daq-{{ snort_daq_version }}-1.f21.x86_64.rpm'
 snort_home_net: 192.168.0.0/16  #define your home_net..if snort_external_net is any then set this to any
 snort_interface: '{{ ansible_default_ipv4.interface }}'  #defines snort interface to listen on
@@ -178,6 +178,13 @@ snort_preproc_rules: []
   #- preprocessor.rules
   #- decoder.rules
   #- sensitive-data.rules
+snort_redhat_prereqs:
+  # libpcap-devel has required libpcap dep anyway
+  - libdnet
+  - libpcap-devel
+  - perl
+  - tcpdump
+  - wget
 snort_redhat_daq_package: 'https://www.snort.org/downloads/snort/daq-{{ snort_daq_version }}-1.centos7.x86_64.rpm'
 snort_redhat_package: 'https://www.snort.org/downloads/snort/snort-{{ snort_version }}-1.centos7.x86_64.rpm'
 snort_redhat_rules:  #defines rules downloaded from emerging threats using oinkmaster
@@ -241,5 +248,5 @@ snort_send_stats: true  #true/false
 snort_src_dir: '/opt/snort_src'  #defines where to download source packages to compile
 snort_startup: boot
 snort_stats_threshold: 1
-snort_version: 2.9.8.2
+snort_version: 2.9.11.1
 snort_whitelist_path: '/etc/snort/rules'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,26 +1,9 @@
 ---
 - name: redhat | installing pre-reqs
-  yum:
+  package:
     name: "{{ item }}"
     state: present
-  with_items:
-    - libpcap
-    - libpcap-devel
-    - perl
-    - tcpdump
-  when: ansible_distribution != "Fedora"
-
-- name: redhat | installing pre-reqs
-  dnf:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libpcap
-    - libpcap-devel
-    - perl
-    - tcpdump
-    - wget
-  when: ansible_distribution == "Fedora"
+  with_items: "{{ snort_redhat_prereqs }}"
 
 - name: redhat | installing snort daq
   yum:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -29,7 +29,7 @@
     state: present
   when: ansible_distribution == "Fedora"
 
-- name: debian | ensuring directory exists (/usr/local/lib/snort_dynamicrules)
+- name: redhat | ensuring directory exists (/usr/local/lib/snort_dynamicrules)
   file:
     dest: "/usr/local/lib/snort_dynamicrules"
     state: directory
@@ -37,6 +37,13 @@
     group: root
     mode: 0755
     recurse: yes
+
+# Has Snort been packaged incorrectly? Shouldn't need to do this
+- name: redhat | ensuring libdnet.1 symlink exists
+  file:
+    dest: "/usr/lib64/libdnet.1"
+    src: "/usr/lib64/libdnet.so.1"
+    state: link
 
 - name: redhat | ensuring snort is enabled
   service:


### PR DESCRIPTION
When testing this today the snort daemon didn't start …

```
Apr 03 20:11:52 c7 systemd[1]: Starting SYSV: snort is a lightweight network intrusion detection tool that 
Apr 03 20:11:52 c7 snortd[6836]: Starting snort: /usr/sbin/snort: error while loading shared libraries: lib
```

(sorry, output truncated)

Basically, the snort binary is looking for 'libdnet.1' – which should of course be 'libdnet.so.1' …

```
[root@c7 lib64]# ldd /usr/sbin/snort
    ...
	libdnet.1 => not found


[root@c7 lib64]# ls -l libdnet.*
lrwxrwxrwx. 1 root root    16 Aug  3  2017 libdnet.so.1 -> libdnet.so.1.0.1
-rwxr-xr-x. 1 root root 62272 Aug  3  2017 libdnet.so.1.0.1
```

I don't know if this is a packaging problem with the latest Snort (2.9.11.1 as I write this) or what – couldn't find any explanation on snort.org. Dirty hack is a symlink – which this PR puts into place. You may or may not choose to accept this, I grant you :) See what you think. I guess it's fairly innocuous, even if they do fix the library pointer in the binary at a later date (could always pull this task then). As it stands today though, you'd need to do this to get snort to even start.
